### PR TITLE
docs: domain mapping; update AI button link to ai.hexcarb.in

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -1,0 +1,5 @@
+# Domain Mapping
+
+1. In Heroku → **Settings** → **Domains**, add `ai.hexcarb.in` and copy the Heroku DNS target.
+2. In GoDaddy DNS, create a CNAME record for `ai` pointing to the Heroku DNS target from step 1.
+3. Wait for the DNS changes to propagate; verify that https://ai.hexcarb.in resolves.

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
       <a href="#applications" class="hover:underline">Applications</a>
       <a href="#vision" class="hover:underline">Vision</a>
       <a href="#roadmap" class="hover:underline">Roadmap</a>
-      <a href="https://hexcarb-ai-clean-4f7af858be70.herokuapp.com/" target="_blank" class="inline-block bg-black text-white px-4 py-2 rounded hover:bg-gray-800 transition">
+      <a href="https://ai.hexcarb.in/" target="_blank" class="inline-block bg-black text-white px-4 py-2 rounded hover:bg-gray-800 transition">
         Hexcarb AI Brain
       </a>
     </div>


### PR DESCRIPTION
## Summary
- document Heroku and GoDaddy domain mapping steps
- point "Hexcarb AI Brain" button to https://ai.hexcarb.in/

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_689b0d23a1ac832f9074e3f2a31842d2